### PR TITLE
✨[FEAT] 네비게이션바 커스텀 및 FilterVC 컬렉션뷰 레이아웃 수정 (#24)

### DIFF
--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
@@ -23,7 +23,7 @@
                                 <rect key="frame" x="0.0" y="88" width="375" height="64"/>
                                 <subviews>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2ve-ct-aY6">
-                                        <rect key="frame" x="0.0" y="16" width="375" height="32"/>
+                                        <rect key="frame" x="16" y="16" width="359" height="32"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="m7r-FT-qPw"/>
@@ -50,7 +50,7 @@
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="2ve-ct-aY6" secondAttribute="bottom" constant="16" id="OdW-Uc-3Xg"/>
                                     <constraint firstItem="2ve-ct-aY6" firstAttribute="top" secondItem="hgM-Ru-urP" secondAttribute="top" constant="16" id="T5z-Wj-cKg"/>
-                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="leading" secondItem="hgM-Ru-urP" secondAttribute="leading" id="TIZ-pi-qD0"/>
+                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="leading" secondItem="hgM-Ru-urP" secondAttribute="leading" constant="16" id="TIZ-pi-qD0"/>
                                     <constraint firstAttribute="trailing" secondItem="2ve-ct-aY6" secondAttribute="trailing" id="oat-51-Nif"/>
                                 </constraints>
                             </view>

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
@@ -20,26 +20,26 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hgM-Ru-urP">
-                                <rect key="frame" x="0.0" y="104" width="375" height="48"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="64"/>
                                 <subviews>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2ve-ct-aY6">
-                                        <rect key="frame" x="0.0" y="8" width="375" height="32"/>
+                                        <rect key="frame" x="0.0" y="16" width="375" height="32"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="32" id="s7r-1p-Ezw"/>
+                                            <constraint firstAttribute="height" constant="32" id="m7r-FT-qPw"/>
                                         </constraints>
                                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="wVG-27-bnb">
-                                            <size key="itemSize" width="128" height="24"/>
+                                            <size key="itemSize" width="128" height="32"/>
                                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                         </collectionViewFlowLayout>
                                         <cells>
                                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="FilterCVC" id="2gV-NZ-PH4" customClass="FilterCVC" customModule="SOPT_29th_JointSeminar10_iOS" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="4" width="128" height="24"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="128" height="32"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="cS1-n1-5Sp">
-                                                    <rect key="frame" x="0.0" y="0.0" width="128" height="24"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="128" height="32"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </collectionViewCellContentView>
                                             </collectionViewCell>
@@ -48,11 +48,10 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="2ve-ct-aY6" secondAttribute="bottom" constant="8" id="7qk-J2-0Jh"/>
-                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="top" secondItem="hgM-Ru-urP" secondAttribute="top" constant="8" id="TTC-wb-FwG"/>
-                                    <constraint firstAttribute="trailing" secondItem="2ve-ct-aY6" secondAttribute="trailing" id="ftt-bW-MLb"/>
-                                    <constraint firstAttribute="height" constant="48" id="oj5-PQ-4mY"/>
-                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="leading" secondItem="hgM-Ru-urP" secondAttribute="leading" id="yEl-X4-tMa"/>
+                                    <constraint firstAttribute="bottom" secondItem="2ve-ct-aY6" secondAttribute="bottom" constant="16" id="OdW-Uc-3Xg"/>
+                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="top" secondItem="hgM-Ru-urP" secondAttribute="top" constant="16" id="T5z-Wj-cKg"/>
+                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="leading" secondItem="hgM-Ru-urP" secondAttribute="leading" id="TIZ-pi-qD0"/>
+                                    <constraint firstAttribute="trailing" secondItem="2ve-ct-aY6" secondAttribute="trailing" id="oat-51-Nif"/>
                                 </constraints>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="tbU-BV-ywt">
@@ -79,12 +78,12 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" name="gray020"/>
                         <constraints>
-                            <constraint firstItem="tbU-BV-ywt" firstAttribute="top" secondItem="hgM-Ru-urP" secondAttribute="bottom" constant="16" id="2Cf-Lj-2ot"/>
+                            <constraint firstItem="hgM-Ru-urP" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="3ka-av-mxm"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="tbU-BV-ywt" secondAttribute="bottom" constant="16" id="6Dh-yD-KO5"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="hgM-Ru-urP" secondAttribute="trailing" id="Ig3-LW-Wrf"/>
-                            <constraint firstItem="hgM-Ru-urP" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="QBG-Qe-yZu"/>
+                            <constraint firstItem="hgM-Ru-urP" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="7ey-jN-ijc"/>
+                            <constraint firstItem="tbU-BV-ywt" firstAttribute="top" secondItem="hgM-Ru-urP" secondAttribute="bottom" constant="16" id="IZa-XP-TkT"/>
+                            <constraint firstItem="hgM-Ru-urP" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="cjd-0x-laN"/>
                             <constraint firstItem="tbU-BV-ywt" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="e8C-cP-SUu"/>
-                            <constraint firstItem="hgM-Ru-urP" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="16" id="eZ5-OV-MwR"/>
                             <constraint firstItem="tbU-BV-ywt" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" constant="-16" id="joo-hg-h7T"/>
                         </constraints>
                     </view>

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
@@ -22,7 +22,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hgM-Ru-urP">
                                 <rect key="frame" x="0.0" y="88" width="375" height="64"/>
                                 <subviews>
-                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2ve-ct-aY6">
+                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2ve-ct-aY6">
                                         <rect key="frame" x="0.0" y="16" width="375" height="32"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
@@ -54,7 +54,7 @@
                                     <constraint firstAttribute="trailing" secondItem="2ve-ct-aY6" secondAttribute="trailing" id="oat-51-Nif"/>
                                 </constraints>
                             </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="tbU-BV-ywt">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="tbU-BV-ywt">
                                 <rect key="frame" x="16" y="168" width="343" height="594"/>
                                 <color key="backgroundColor" name="gray020"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gal-LU-DgW">
@@ -91,6 +91,7 @@
                     <splitViewDetailSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <connections>
                         <outlet property="filterCV" destination="2ve-ct-aY6" id="054-Me-RHY"/>
+                        <outlet property="filterView" destination="hgM-Ru-urP" id="Whf-hx-Pgq"/>
                         <outlet property="reservationCV" destination="tbU-BV-ywt" id="U90-rH-8iB"/>
                     </connections>
                 </viewController>

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Resource/Storyboards/Filter.storyboard
@@ -23,7 +23,7 @@
                                 <rect key="frame" x="0.0" y="88" width="375" height="64"/>
                                 <subviews>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="2ve-ct-aY6">
-                                        <rect key="frame" x="16" y="16" width="359" height="32"/>
+                                        <rect key="frame" x="0.0" y="16" width="375" height="32"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="m7r-FT-qPw"/>
@@ -50,7 +50,7 @@
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="2ve-ct-aY6" secondAttribute="bottom" constant="16" id="OdW-Uc-3Xg"/>
                                     <constraint firstItem="2ve-ct-aY6" firstAttribute="top" secondItem="hgM-Ru-urP" secondAttribute="top" constant="16" id="T5z-Wj-cKg"/>
-                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="leading" secondItem="hgM-Ru-urP" secondAttribute="leading" constant="16" id="TIZ-pi-qD0"/>
+                                    <constraint firstItem="2ve-ct-aY6" firstAttribute="leading" secondItem="hgM-Ru-urP" secondAttribute="leading" id="TIZ-pi-qD0"/>
                                     <constraint firstAttribute="trailing" secondItem="2ve-ct-aY6" secondAttribute="trailing" id="oat-51-Nif"/>
                                 </constraints>
                             </view>

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/Cell/FilterCVC.swift
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/Cell/FilterCVC.swift
@@ -9,11 +9,8 @@ import UIKit
 
 class FilterCVC: UICollectionViewCell {
     
-    @IBOutlet weak var filterView: UIView!
     @IBOutlet weak var titleButton: UIButton!
     @IBOutlet weak var closeButton: UIButton!
-    
-    var closeButtonWidth: NSLayoutConstraint! = NSLayoutConstraint()
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -21,10 +18,6 @@ class FilterCVC: UICollectionViewCell {
     }
     
     func setUI() {
-        filterView.layer.cornerRadius = 0.17 * filterView.bounds.size.width
-        filterView.layer.borderColor = UIColor.gray040.cgColor
-        filterView.layer.borderWidth = 1.3
-        
         titleButton.translatesAutoresizingMaskIntoConstraints = false
         titleButton.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
         titleButton.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
@@ -35,8 +28,7 @@ class FilterCVC: UICollectionViewCell {
         closeButton.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
         closeButton.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
         closeButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 0).isActive = true
-        closeButtonWidth = closeButton.widthAnchor.constraint(lessThanOrEqualToConstant: 0)
-        closeButtonWidth.isActive = true
+        closeButton.widthAnchor.constraint(lessThanOrEqualToConstant: 0).isActive = true
         
     }
 

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/Cell/FilterCVC.xib
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/Cell/FilterCVC.xib
@@ -6,7 +6,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,71 +18,54 @@
                 <rect key="frame" x="0.0" y="0.0" width="100" height="32"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KOA-75-Ncd">
-                        <rect key="frame" x="0.0" y="0.0" width="100" height="32"/>
-                        <subviews>
-                            <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DtE-rF-Qci">
-                                <rect key="frame" x="0.0" y="0.0" width="76" height="32"/>
-                                <color key="tintColor" name="gray060"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain">
-                                    <attributedString key="attributedTitle">
-                                        <fragment content="Button">
-                                            <attributes>
-                                                <font key="NSFont" size="12" name="SpoqaHanSansNeo-Regular"/>
-                                            </attributes>
-                                        </fragment>
-                                    </attributedString>
-                                </buttonConfiguration>
-                            </button>
-                            <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hID-bf-DKv">
-                                <rect key="frame" x="76" y="0.0" width="24" height="32"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="24" id="NI5-Hb-STF"/>
-                                </constraints>
-                                <color key="tintColor" name="whtie"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title=""/>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hID-bf-DKv">
+                        <rect key="frame" x="59" y="0.0" width="41" height="32"/>
+                        <color key="tintColor" name="whtie"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="" buttonSize="mini"/>
+                    </button>
+                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DtE-rF-Qci">
+                        <rect key="frame" x="0.0" y="0.0" width="59" height="32"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="hID-bf-DKv" secondAttribute="trailing" id="1DD-8h-wH3"/>
-                            <constraint firstItem="DtE-rF-Qci" firstAttribute="leading" secondItem="KOA-75-Ncd" secondAttribute="leading" id="25F-Ib-MT6"/>
-                            <constraint firstItem="hID-bf-DKv" firstAttribute="top" secondItem="KOA-75-Ncd" secondAttribute="top" id="E5C-XW-V7C"/>
-                            <constraint firstItem="hID-bf-DKv" firstAttribute="leading" secondItem="DtE-rF-Qci" secondAttribute="trailing" id="EFF-rO-6Th"/>
-                            <constraint firstAttribute="bottom" secondItem="hID-bf-DKv" secondAttribute="bottom" id="FEY-Fq-ItB"/>
-                            <constraint firstAttribute="bottom" secondItem="DtE-rF-Qci" secondAttribute="bottom" id="KL4-Do-WXK"/>
-                            <constraint firstItem="DtE-rF-Qci" firstAttribute="top" secondItem="KOA-75-Ncd" secondAttribute="top" id="boE-oR-KdW"/>
-                            <constraint firstItem="hID-bf-DKv" firstAttribute="leading" secondItem="DtE-rF-Qci" secondAttribute="trailing" id="iAp-Ae-KVV"/>
+                            <constraint firstAttribute="height" constant="32" id="IoG-lt-gyK"/>
                         </constraints>
-                    </view>
+                        <color key="tintColor" name="gray005"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" buttonSize="mini">
+                            <attributedString key="attributedTitle">
+                                <fragment content="Button">
+                                    <attributes>
+                                        <font key="NSFont" size="12" name="SpoqaHanSansNeo-Regular"/>
+                                    </attributes>
+                                </fragment>
+                            </attributedString>
+                        </buttonConfiguration>
+                    </button>
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
-                <constraint firstItem="KOA-75-Ncd" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="4vR-RY-Qw1"/>
-                <constraint firstAttribute="bottom" secondItem="KOA-75-Ncd" secondAttribute="bottom" id="MO3-B8-tpw"/>
-                <constraint firstItem="KOA-75-Ncd" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="Qgv-ld-YOZ"/>
-                <constraint firstAttribute="trailing" secondItem="KOA-75-Ncd" secondAttribute="trailing" id="lED-Yk-aZb"/>
+                <constraint firstItem="DtE-rF-Qci" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="KEE-JA-r0G"/>
+                <constraint firstAttribute="bottom" secondItem="DtE-rF-Qci" secondAttribute="bottom" id="PAZ-S2-Gag"/>
+                <constraint firstItem="hID-bf-DKv" firstAttribute="leading" secondItem="DtE-rF-Qci" secondAttribute="trailing" id="Q3r-Zb-rfL"/>
+                <constraint firstAttribute="bottom" secondItem="hID-bf-DKv" secondAttribute="bottom" id="Uug-3g-e0a"/>
+                <constraint firstItem="hID-bf-DKv" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="dfB-od-DxK"/>
+                <constraint firstAttribute="trailing" secondItem="hID-bf-DKv" secondAttribute="trailing" id="jof-VJ-ef7"/>
+                <constraint firstItem="DtE-rF-Qci" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="xd8-Zi-Zf2"/>
             </constraints>
             <connections>
                 <outlet property="closeButton" destination="hID-bf-DKv" id="Pom-a2-uMG"/>
-                <outlet property="filterView" destination="KOA-75-Ncd" id="5xX-yc-l21"/>
                 <outlet property="titleButton" destination="DtE-rF-Qci" id="eRx-FW-Taf"/>
             </connections>
             <point key="canvasLocation" x="140.57971014492756" y="93.75"/>
         </collectionViewCell>
     </objects>
     <resources>
-        <namedColor name="gray060">
-            <color red="0.21600000560283661" green="0.27099999785423279" blue="0.32499998807907104" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="gray005">
+            <color red="0.99599999189376831" green="0.99599999189376831" blue="0.99599999189376831" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="whtie">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
@@ -18,7 +18,7 @@ class FilterVC: UIViewController {
     let reserveContentList: [ReservationCarModel] = []
     var isClickedFilter: [Int] = [0, 0, 0, 0, 0, 0]
     let beforeFiltered: [String] = ["초기화", "대여기간", "차종", "지역", "가격", "인기"]
-    let afterFiltered: [String] = ["", "", "준중형", "서울/경기/인천", "낮은 가격 순", "인기"]
+    let afterFiltered: [String] = ["초기화", "3개월 | 2021", "준중형", "서울/경기/인천", "낮은 가격 순", "인기"]
     
     // MARK: - View Life Cycle
     
@@ -101,32 +101,44 @@ extension FilterVC: UICollectionViewDataSource {
            
             if isClickedFilter[indexPath.row] == 1 {
                 cell.closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
-                cell.closeButtonWidth.isActive = false
+                cell.closeButton.widthAnchor.constraint(equalToConstant: 37).isActive = true
+                cell.closeButton.leadingAnchor.constraint(equalTo: cell.titleButton.trailingAnchor, constant: -20).isActive = true
                 
                 let attribute = [NSAttributedString.Key.font: UIFont.cap1R, NSAttributedString.Key.foregroundColor: UIColor.white]
                 cell.titleButton.setAttributedTitle(NSAttributedString(string:afterFiltered[indexPath.row], attributes: attribute), for: .normal)
                 
-                cell.filterView.backgroundColor = UIColor.gray060
-                cell.filterView.layer.borderWidth = 0
+                cell.layer.backgroundColor = UIColor.gray060.cgColor
+                cell.layer.borderWidth = 0
+                cell.layer.cornerRadius = 0.042 * filterView.bounds.size.width
                 
                 cell.titleButton.setTitleColor(UIColor.white, for: .normal)
                 
                 let attributedTitle = cell.titleButton.attributedTitle(for: .normal)
-                cell.filterView.frame.size.width = attributedTitle!.size().width
+                cell.titleButton.frame.size.width = attributedTitle!.size().width + 25
+                cell.layer.frame.size.width = cell.titleButton.frame.size.width + 37
             } else {
-                cell.closeButton.frame.size.width = 0
                 cell.closeButton.setImage(UIImage(), for: .normal)
                 
                 let attribute = [NSAttributedString.Key.font: UIFont.cap1R, NSAttributedString.Key.foregroundColor: UIColor.gray060]
                 cell.titleButton.setAttributedTitle(NSAttributedString(string:beforeFiltered[indexPath.row], attributes: attribute), for: .normal)
                 
-                cell.filterView.backgroundColor = UIColor.white
-                cell.filterView.layer.borderWidth = 1.3
+                cell.layer.backgroundColor = UIColor.white.cgColor
+                cell.layer.borderWidth = 1.3
+                cell.layer.cornerRadius = 0.042 * filterView.bounds.size.width
+                cell.layer.borderColor = UIColor.gray040.cgColor
                 
                 cell.titleButton.setTitleColor(UIColor.gray060, for: .normal)
                 
                 let attributedTitle = cell.titleButton.attributedTitle(for: .normal)
-                cell.filterView.frame.size.width = attributedTitle!.size().width + 37
+                cell.layer.frame.size.width = attributedTitle!.size().width + 30
+                
+                if indexPath.row == 0{
+                    cell.titleButton.setImage(UIImage(named: "defaultHome"), for: .normal)
+                    cell.layer.frame.size.width = attributedTitle!.size().width + 30 + 15
+                } else if indexPath.row == 5 {
+                    cell.titleButton.setImage(UIImage(named: "group17"), for: .normal)
+                    cell.layer.frame.size.width = attributedTitle!.size().width + 30 + 15
+                }
             }
             
             return cell
@@ -145,35 +157,48 @@ extension FilterVC: UICollectionViewDelegateFlowLayout {
            
             if isClickedFilter[indexPath.row] == 1 {
                 cell!.closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
-                cell!.closeButtonWidth.isActive = false
+                cell!.closeButton.widthAnchor.constraint(equalToConstant: 37).isActive = true
+                cell!.closeButton.leadingAnchor.constraint(equalTo: cell!.titleButton.trailingAnchor, constant: -10).isActive = true
                 
                 let attribute = [NSAttributedString.Key.font: UIFont.cap1R, NSAttributedString.Key.foregroundColor: UIColor.white]
                 cell!.titleButton.setAttributedTitle(NSAttributedString(string:afterFiltered[indexPath.row], attributes: attribute), for: .normal)
-                
-                cell!.filterView.backgroundColor = UIColor.gray060
-                cell!.filterView.layer.borderWidth = 0
+               
+                cell!.layer.backgroundColor = UIColor.gray060.cgColor
+                cell!.layer.borderWidth = 0
+                cell!.layer.cornerRadius = 0.042 * filterView.bounds.size.width
+                cell!.layer.borderColor = UIColor.gray040.cgColor
                 
                 cell!.titleButton.setTitleColor(UIColor.white, for: .normal)
                 
                 let attributedTitle = cell!.titleButton.attributedTitle(for: .normal)
-                cell!.filterView.frame.size.width = attributedTitle!.size().width + 37
+                cell!.titleButton.frame.size.width = attributedTitle!.size().width + 25
+                cell!.layer.frame.size.width = cell!.titleButton.frame.size.width + 37
+                
             } else {
-                cell!.closeButton.frame.size.width = 0
                 cell!.closeButton.setImage(UIImage(), for: .normal)
                 
                 let attribute = [NSAttributedString.Key.font: UIFont.cap1R, NSAttributedString.Key.foregroundColor: UIColor.gray060]
                 cell!.titleButton.setAttributedTitle(NSAttributedString(string:beforeFiltered[indexPath.row], attributes: attribute), for: .normal)
                 
-                cell!.filterView.backgroundColor = UIColor.white
-                cell!.filterView.layer.borderWidth = 1.3
+                cell!.layer.backgroundColor = UIColor.white.cgColor
+                cell!.layer.borderWidth = 1.3
+                cell!.layer.cornerRadius = 0.042 * filterView.bounds.size.width
                 
                 cell!.titleButton.setTitleColor(UIColor.gray060, for: .normal)
                 
                 let attributedTitle = cell!.titleButton.attributedTitle(for: .normal)
-                cell!.filterView.frame.size.width = attributedTitle!.size().width
+                cell!.layer.frame.size.width = attributedTitle!.size().width + 30
+                
+                if indexPath.row == 0{
+                    cell!.titleButton.setImage(UIImage(named: "defaultHome"), for: .normal)
+                    cell!.layer.frame.size.width = attributedTitle!.size().width + 30 + 15
+                } else if indexPath.row == 5 {
+                    cell!.titleButton.setImage(UIImage(named: "group17"), for: .normal)
+                    cell!.layer.frame.size.width = attributedTitle!.size().width + 30 + 15
+                }
             }
             
-            return CGSize(width: cell!.filterView.frame.size.width + 37, height: 32)
+            return CGSize(width: cell!.layer.frame.size.width, height: 32)
         } else {
             guard let flowLayout = collectionViewLayout as? UICollectionViewFlowLayout else { return CGSize() }
             let numberOfCellsOfWidth: CGFloat = 2

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
@@ -13,6 +13,7 @@ class FilterVC: UIViewController {
 
     @IBOutlet weak var filterCV: UICollectionView!
     @IBOutlet weak var reservationCV: UICollectionView!
+    @IBOutlet weak var filterView: UIView!
     
     let reserveContentList: [ReservationCarModel] = []
     var isClickedFilter: [Int] = [0, 0, 0, 0, 0, 0]
@@ -36,6 +37,9 @@ class FilterVC: UIViewController {
         self.navigationItem.backButtonTitle = ""
         let backbutton = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .done, target: self, action: #selector(touchNavBackButton))
         self.navigationItem.leftBarButtonItem = backbutton
+        
+        self.filterView.layer.applyShadow(color: .black, alpha: 0.04, x: 0, y: 3.62319, blur: 3.62319, spread: 0)
+        
     }
     
     func setDelegate() {

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
@@ -26,9 +26,17 @@ class FilterVC: UIViewController {
         
         setDelegate()
         registerXib()
+        setUI()
     }
     
     // MARK: - Custom Methods
+    
+    func setUI() {
+        self.navigationItem.title = "차량 예약"
+        self.navigationItem.backButtonTitle = ""
+        let backbutton = UIBarButtonItem(image: UIImage(systemName: "arrow.left"), style: .done, target: self, action: #selector(touchNavBackButton))
+        self.navigationItem.leftBarButtonItem = backbutton
+    }
     
     func setDelegate() {
         filterCV.delegate = self
@@ -48,6 +56,12 @@ class FilterVC: UIViewController {
         filterCV.register(filterXibName, forCellWithReuseIdentifier: Const.Xib.NibName.filterCVC)
         let reservationXibName = UINib(nibName: Const.Xib.NibName.reservationCVC, bundle: nil)
         reservationCV.register(reservationXibName, forCellWithReuseIdentifier: Const.Xib.NibName.reservationCVC)
+    }
+    
+    // MARK: - @objc functions
+    
+    @objc func touchNavBackButton() {
+        self.navigationController?.popViewController(animated: true)
     }
 }
 

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/FilterVC.swift
@@ -189,7 +189,7 @@ extension FilterVC: UICollectionViewDelegateFlowLayout {
                 let attributedTitle = cell!.titleButton.attributedTitle(for: .normal)
                 cell!.layer.frame.size.width = attributedTitle!.size().width + 30
                 
-                if indexPath.row == 0{
+                if indexPath.row == 0 {
                     cell!.titleButton.setImage(UIImage(named: "defaultHome"), for: .normal)
                     cell!.layer.frame.size.width = attributedTitle!.size().width + 30 + 15
                 } else if indexPath.row == 5 {
@@ -210,7 +210,11 @@ extension FilterVC: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets.zero
+        if collectionView == filterCV {
+            return UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        } else {
+            return UIEdgeInsets.zero
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {

--- a/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/Tabar/MainTabVC.swift
+++ b/SOPT-29th-JointSeminar10-iOS/SOPT-29th-JointSeminar10-iOS/Source/ViewController/Tabar/MainTabVC.swift
@@ -29,6 +29,18 @@ extension MainTabVC {
               let myPageVC = self.storyboard?.instantiateViewController(withIdentifier: Const.ViewController.Identifier.myPage) else { return }
         let carPlanNVC = UINavigationController(rootViewController: carPlanVC)
         
+        // TODO: - 네비게이션 바 iOS 15 미만 대응
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()    // 불투명하게
+        appearance.backgroundColor = UIColor.white
+        appearance.shadowColor = .white
+        appearance.shadowImage = UIImage()
+        appearance.titleTextAttributes = [NSAttributedString.Key.font: UIFont.sub2M]
+        carPlanNVC.navigationBar.standardAppearance = appearance
+        carPlanNVC.navigationBar.scrollEdgeAppearance = carPlanNVC.navigationBar.standardAppearance    // 동일하게 만들기
+        carPlanNVC.navigationBar.tintColor = UIColor.gray070
+        
         homeVC.tabBarItem = UITabBarItem(title: "홈", image: .defaultHome, selectedImage: .selectedHome)
         carPlanNVC.tabBarItem = UITabBarItem(title: "차량플랜", image: .defaultCarplan, selectedImage: .selectedCarplan)
         pairingVC.tabBarItem = UITabBarItem(title: "페어링", image: .defaultPairing, selectedImage: .selectedPairing)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed #Issue_number를 적어주세요 -->
closed #24
  

## 📌 변경 사항 및 이유
<!-- 변경한 내용과 그 이유를 적어주세요. -->
 - 네비게이션바 커스텀
 - filterVC 네비게이션 아이템 설정
 - 필터 컬션뷰 그림자 설정
 - 필터 컬렉션뷰 오토레이아웃 수정

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
* 초기화 아이콘이 없어 임시로 홈 이미지로 대체했읍니다...!
![스크린샷 2021-11-24 오후 3 44 25](https://user-images.githubusercontent.com/46108770/143188256-c61834e5-10e7-48ba-a0e2-30297b94db45.png)

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
* 필터 컬렉션뷰 왼쪽 시작 간격을 맞추고 싶어서 leadingAnchor를 16으로 줬더니 아래처럼 잘리는데요 ... 이게 맞을까요...? 😂
![스크린샷 2021-11-24 오후 3 45 41](https://user-images.githubusercontent.com/46108770/143188435-a418cf12-193b-4d1b-86af-0256df1b7a38.png)


